### PR TITLE
Add missing custom resource page for managing navbar option

### DIFF
--- a/resources/views/filament/resources/nav-bar-option-resource/pages/create-custom-nav-bar.blade.php
+++ b/resources/views/filament/resources/nav-bar-option-resource/pages/create-custom-nav-bar.blade.php
@@ -1,0 +1,13 @@
+<x-filament-panels::page>
+    <div class="grid" style="grid-template-columns: repeat(2, minmax(0, 1fr));gap: 10px">
+        <div class="col-span-1">
+            <x-filament-panels::form wire:submit="submit">
+                {{ $this->form }}
+                <x-filament-panels::form.actions :actions="$this->getFormActions()" />
+            </x-filament-panels::form>
+        </div>
+        <div class="col-span-1">
+            {{ $this->table }}
+        </div>
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
This is a custom filament resource page that have a form and a table in the same page. in this page you can manage the navigation bar option of the website. it allows the following actions:

* create
* list
* edit
* delete

Authored-by: Jhonatan Martinez