### PR TITLE
Add products suggestions to original product details web page

### DIFF
--- a/resources/views/product-details.blade.php
+++ b/resources/views/product-details.blade.php
@@ -12,10 +12,6 @@
     @include('partials.spinner')
     <!-- Spinner End -->
 
-    <!-- Topbar Start -->
-  
-    <!-- Topbar End -->
-
     <!-- Navbar Start -->
     <div class="container-fluid position-relative p-0">
         @include('partials.navbar')
@@ -46,17 +42,19 @@
                         <div class="carousel-inner" role="listbox">
                             <!------------- list of images for use into the carousel from the product images list ------------->
                             @foreach ($product->images as $index => $imagePath)
-                                @if ($index == 0)
-                                <div class="carousel-item active">
-                                    <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
-                                        class="rounded mx-auto d-block" style="object-fit: contain; max-width: 100%; height: 20rem;">
-                                </div>
-                                @else
-                                <div class="carousel-item">
-                                    <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
-                                        class="rounded mx-auto d-block" style="object-fit: contain; max-width: 100%; height: 20rem;">
-                                </div>
-                                @endif
+                            @if ($index == 0)
+                            <div class="carousel-item active">
+                                <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
+                                    class="rounded mx-auto d-block"
+                                    style="object-fit: contain; max-width: 100%; height: 20rem;">
+                            </div>
+                            @else
+                            <div class="carousel-item">
+                                <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
+                                    class="rounded mx-auto d-block"
+                                    style="object-fit: contain; max-width: 100%; height: 20rem;">
+                            </div>
+                            @endif
                             @endforeach
                         </div>
                         <button class="carousel-control-prev" type="button" data-bs-target="#carouselId"
@@ -86,6 +84,47 @@
     </div>
     </div>
     <!-- Blog End -->
+
+    <!-------- related product to category of current product details --------->
+    <div class="container-fluid product py-2">
+        <div class="container">
+            <!------------ category section title ------------>
+            <div class="mb-3">
+                <h2>Relacionados</h2>
+            </div>
+            @foreach ($relatedProductsGroupByCategory as $categorizedProducts)
+            <!------------ grouped products by category ------------>
+            <div class="row" id={{ strtolower($categorizedProducts['categoryName']) }}>
+                @foreach ($categorizedProducts['products'] as $product)
+                    <div class="col-lg-4 col-md-6">
+                        <div class="product-item">
+                            <div class="product-img">
+                                <div class="product-img-inner">
+                                    <img class="img-fluid w-100 rounded-top" src={{ asset('/storage/' . $product->thumbnail)}}
+                                        alt="Image" style="height: 300px;">
+                                    <div class="product-icon">
+                                        <a href={{ url('/products/' . $product->id . '/details') }} class="my-auto"><i
+                                                class="fas fa-link fa-2x text-white"></i></a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="product-content border border-top-0 rounded-bottom p-4">
+                                <a href={{ url('/products/' . $product->id . '/details') }} class="h4 mb-5"
+                                    style="width: 100%;">{{ $product->title}}</a>
+                                <a href={{ url('/products/' . $product->id . '/details') }}
+                                    class="btn btn-primary rounded-pill py-2 px-4 mt-3 text-light" style="width:
+                                            100%;">Mas
+                                    Información</a>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+            <!------------ End of grouped products by category ------------>
+            @endforeach
+        </div>
+    </div>
+    <!-------- End of related product to category of current product details --------->
 
     <!---------- JAVASCRIPT ---------->
     @include('partials.footer')


### PR DESCRIPTION
## Description

in the product-details website page, added a section in the bottom side to visualize the products that are related to the current product category. this way the user can watch other suggestions and get more options

**Before:**

![product-details-original-web-page](https://github.com/user-attachments/assets/e71d4777-5af2-4804-b97f-50db977f2f46)


**After:**

![product-details-web-page-with-related-products](https://github.com/user-attachments/assets/f829a9cb-573d-42a7-bd45-c601649b1735)



Authored-by: Jhonatan Martinez