### PR TITLE
Switch contact phone number position in website footer

### DIFF
--- a/resources/views/partials/footer-info.blade.php
+++ b/resources/views/partials/footer-info.blade.php
@@ -7,8 +7,8 @@
                     <h4 class="mb-4 text-white">Comunicate con Nosotros</h4>
                     <p href=""><i class="fas fa-home me-2"></i> Bocagrande Av. San Martin Cra 2 # 8 – 67 Apartamento 2 - 12 b</p>
                     <p href=""><i class="fas fa-envelope me-2"></i> cartagena.trip.tours@hotmail.com</p>
-                    <p href=""><i class="fas fa-phone me-2"></i> +57 314 8510695</p>
                     <p href="" class="mb-3"><i class="fas fa-phone me-2"></i> +57 317 7417374</p>
+                    <p href=""><i class="fas fa-phone me-2"></i> +57 314 8510695</p>
                 </div>
             </div>
             <!--


### PR DESCRIPTION
## Description

The contact phone numbers where switch. the last number was moved to top and the number that was in the top position was moved to the bottom. this is because one is more used and rapidly answer than the other