### PR TITLE
Refactor some styles at index website page

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1014,6 +1014,30 @@
 }
 /*** Travel Guide End ***/
 
+.custom-product-image {
+    object-fit: fill;
+    position: relative;
+    height: 400px;
+    width: 100%;
+}
+
+@media (min-width: 576px) {
+    .custom-product-image {
+        height: 280px;
+    }
+}
+
+@media (min-width: 768px) {
+    .custom-product-image {
+        height: 350px;
+    }
+}
+
+@media (min-width: 992px) {
+    .custom-product-image {
+        height: 320px;
+    }
+}
 
 /*** product Start ***/
 .product .product-item .product-img {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -68,7 +68,7 @@
     @foreach ($listOfCategorizedProducts as $productCategory)
     <section style="padding-top: 4rem" id={{ strtolower($productCategory['name']) }} >
         <div class="container-fluid product pt-3 pb-1 mt-3">
-            <div class="container">
+            <div class="container-lg">
                 <!------------ category section title ------------>
                 <div class="mx-auto text-center mb-3">
                     <h3 class="section-title px-3">{{ $productCategory['name'] }}</h3>
@@ -77,7 +77,7 @@
                 <div class="row g-4 justify-content-center">
                     @foreach ($productCategory['products'] as $product)
                     <!---product---->
-                    <div class="col-lg-4 col-md-6">
+                    <div class="col-sm-6 col-md-6 col-lg-4">
                         <div class="product-item">
                             <div class="product-img">
                                 <div class="product-img-inner">

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -81,8 +81,8 @@
                         <div class="product-item">
                             <div class="product-img">
                                 <div class="product-img-inner">
-                                    <img class="img-fluid w-100 rounded-top" src={{ asset('/storage/' . $product->thumbnail) }}
-                                            alt="Image" style="height: 400px;">
+                                    <img class="custom-product-image" src={{ asset('/storage/' . $product->thumbnail) }}
+                                            alt="Image">
                                     <div class="product-icon">
                                         <a href={{ url('/products/' . $product->id . '/details') }} class="my-auto"><i
                                                     class="fas fa-link fa-2x text-white"></i></a>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -66,7 +66,7 @@
 
     <!-------- sectin of products grouped by category --------->
     @foreach ($listOfCategorizedProducts as $productCategory)
-    <section id={{ strtolower($productCategory['name']) }}>
+    <section style="padding-top: 4rem" id={{ strtolower($productCategory['name']) }} >
         <div class="container-fluid product pt-3 pb-1 mt-3">
             <div class="container">
                 <!------------ category section title ------------>


### PR DESCRIPTION
## Description

### Sections of products group by category
Add padding in the top of the section so when the user click the navigation bar option that jumps to that section the title can be
visualize correctly and is not hidden

### Product cards

Add css media queries for product images so the can be visualize correctly from any screen size

### Container break point

Add bootstrap break point to apply container styles when the screen size is above 992px