### PR TITLE
Refactor product image carousel in product details page

### DIFF
--- a/public/css/productdetailscarousel.css
+++ b/public/css/productdetailscarousel.css
@@ -1,0 +1,111 @@
+.product-details-carousel .synced-product-image-carousel {
+  margin: 0 auto;
+  max-width: 800px;
+}
+
+.product-details-carousel #main-image {
+  background-color: #fffdfd;
+}
+
+.product-details-carousel #main-image .item {
+  padding: 0px 0px;
+  margin: 2px;
+  height: 180px;
+}
+
+.product-details-carousel #main-image .item img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.product-details-carousel #thumbnails {
+  margin-top: 0.5rem;
+  border-top: 0.1rem solid #333;
+}
+
+.product-details-carousel #thumbnails .item {
+  height: 40px;
+  line-height: 40px;
+  padding: 0px;
+  margin: 2px;
+  border-radius: 3px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.product-details-carousel #thumbnails .item img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.product-details-carousel #main-image.owl-theme {
+  position: relative;
+}
+
+.product-details-carousel #main-image.owl-theme .owl-next,
+.product-details-carousel #main-image.owl-theme .owl-prev,
+.product-details-carousel #thumbnails.owl-theme .owl-next,
+.product-details-carousel #thumbnails.owl-theme .owl-prev {
+  display: none;
+}
+
+/** media queries for mobile devices */
+
+@media (min-width: 360px) {
+
+  .product-details-carousel #main-image .item {
+    height: 240px;
+  }
+}
+
+@media (min-width: 576px) {
+
+  .product-details-carousel #main-image .item {
+    height: 420px;
+  }
+
+  .product-details-carousel #thumbnails .item {
+    height: 70px;
+    line-height: 70px;
+  }
+
+  .product-details-carousel .owl-theme .owl-nav [class*="owl-"] {
+    -webkit-transition: all 0.3s ease;
+    transition: all 0.3s ease;
+  }
+
+  .product-details-carousel .owl-theme .owl-nav [class*="owl-"].disabled:hover {
+    background-color: #d6d6d6;
+  }
+
+  .product-details-carousel #main-image.owl-theme .owl-next,
+  .product-details-carousel #main-image.owl-theme .owl-prev {
+    background: #333;
+    width: 22px;
+    line-height: 40px;
+    height: 40px;
+    margin-top: -20px;
+    position: absolute;
+    text-align: center;
+    top: 50%;
+    display: block;
+  }
+
+  .product-details-carousel #main-image.owl-theme .owl-prev {
+    left: 10px;
+  }
+
+  .product-details-carousel #main-image.owl-theme .owl-next {
+    right: 10px;
+  }
+}
+
+@media (min-width: 768px) {
+
+  .product-details-carousel #thumbnails .item {
+    height: 80px;
+    line-height: 80px;
+  }
+}

--- a/public/js/productdetailscarousel.js
+++ b/public/js/productdetailscarousel.js
@@ -1,0 +1,90 @@
+$(document).ready(function () {
+    var bigimage = $("#main-image");
+    var thumbs = $("#thumbnails");
+    //var totalslides = 10;
+    var syncedSecondary = true;
+
+    bigimage.owlCarousel({
+        items: 1,
+        slideSpeed: 2000,
+        nav: true,
+        autoplay: false,
+        dots: false,
+        loop: true,
+        responsiveRefreshRate: 200,
+        navText: [
+            '<i class="fa fa-arrow-left" aria-hidden="true"></i>',
+            '<i class="fa fa-arrow-right" aria-hidden="true"></i>'
+        ]
+    }).on("changed.owl.carousel", syncPosition);
+
+    thumbs.on("initialized.owl.carousel", function () {
+        thumbs
+            .find(".owl-item")
+            .eq(0)
+            .addClass("current");
+    }).owlCarousel({
+        items: 4,
+        dots: true,
+        nav: true,
+        navText: [
+            '<i class="fa fa-arrow-left" aria-hidden="true"></i>',
+            '<i class="fa fa-arrow-right" aria-hidden="true"></i>'
+        ],
+        smartSpeed: 200,
+        slideSpeed: 500,
+        slideBy: 4,
+        responsiveRefreshRate: 100
+    }).on("changed.owl.carousel", syncPosition2);
+
+    function syncPosition(el) {
+        //if loop is set to false, then you have to uncomment the next line
+        //var current = el.item.index;
+
+        //to disable loop, comment this block
+        var count = el.item.count - 1;
+        var current = Math.round(el.item.index - el.item.count / 2 - 0.5);
+
+        if (current < 0) {
+            current = count;
+        }
+        if (current > count) {
+            current = 0;
+        }
+        //to this
+        thumbs
+            .find(".owl-item")
+            .removeClass("current")
+            .eq(current)
+            .addClass("current");
+        var onscreen = thumbs.find(".owl-item.active").length - 1;
+        var start = thumbs
+            .find(".owl-item.active")
+            .first()
+            .index();
+        var end = thumbs
+            .find(".owl-item.active")
+            .last()
+            .index();
+
+        if (current > end) {
+            thumbs.data("owl.carousel").to(current, 100, true);
+        }
+        if (current < start) {
+            thumbs.data("owl.carousel").to(current - onscreen, 100, true);
+        }
+    }
+
+    function syncPosition2(el) {
+        if (syncedSecondary) {
+            var number = el.item.index;
+            bigimage.data("owl.carousel").to(number, 100, true);
+        }
+    }
+
+    thumbs.on("click", ".owl-item", function (e) {
+        e.preventDefault();
+        var number = $(this).index();
+        bigimage.data("owl.carousel").to(number, 300, true);
+    });
+});

--- a/resources/views/product-details.blade.php
+++ b/resources/views/product-details.blade.php
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <title>Trip Tours Cartagena | Information de Paquetes</title>
     @include('partials.header')
+    <link rel="stylesheet" href={{ asset('css/productdetailscarousel.css') }}>
+    
 </head>
 
 <body>
@@ -22,46 +24,23 @@
     <div class="container-fluid">
         <div class="container py-5">
             <div class="row justify-content-center">
-                <div class="col-lg-6 col-md-6 col-md-12">
-                    <!-- Carousel Start -->
-                    <div id="carouselId" class="carousel slide mb-5" data-bs-ride="carousel">
-                        <ol class="carousel-indicators">
+                <div class="col-lg-6 col-md-6 col-md-12 product-details-carousel">
+                   <!-- carousel with thumbnails -->
+                    <div class="synced-product-image-carousel">
+                        <div id="main-image" class="owl-carousel owl-theme">
                             @foreach ($product->images as $index => $imagePath)
-                                @if ($index == 0)
-                                    <li data-bs-target="#carouselId" data-bs-slide-to="{{ $index }}" class="active"></li>
-                                @else
-                                    <li data-bs-target="#carouselId" data-bs-slide-to="{{ $index }}"></li>
-                                @endif
-                            @endforeach
-                        </ol>
-                        <div class="carousel-inner" role="listbox">
-                            <!------------- list of images for use into the carousel from the product images list ------------->
-                            @foreach ($product->images as $index => $imagePath)
-                            @if ($index == 0)
-                            <div class="carousel-item active">
-                                <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
-                                    class="rounded mx-auto d-block"
-                                    style="object-fit: contain; max-width: 100%; height: 20rem;">
-                            </div>
-                            @else
-                            <div class="carousel-item">
-                                <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image"
-                                    class="rounded mx-auto d-block"
-                                    style="object-fit: contain; max-width: 100%; height: 20rem;">
-                            </div>
-                            @endif
+                                <div class="item">
+                                    <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image">
+                                </div>
                             @endforeach
                         </div>
-                        <button class="carousel-control-prev" type="button" data-bs-target="#carouselId"
-                            data-bs-slide="prev">
-                            <span class="carousel-control-prev-icon btn bg-primary" aria-hidden="false"></span>
-                            <span class="visually-hidden">Previous</span>
-                        </button>
-                        <button class="carousel-control-next" type="button" data-bs-target="#carouselId"
-                            data-bs-slide="next">
-                            <span class="carousel-control-next-icon btn bg-primary" aria-hidden="false"></span>
-                            <span class="visually-hidden">Next</span>
-                        </button>
+                        <div id="thumbnails" class="owl-carousel owl-theme">
+                            @foreach ($product->images as $index => $imagePath)
+                                <div class="item">
+                                    <img src={{ asset('/storage/' . $imagePath) }} alt="carousel-image">
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 </div>
                 <!-- Carousel End -->
@@ -125,6 +104,7 @@
     
     <!---------- JAVASCRIPT ---------->
     @include('partials.footer')
+    <script src={{ asset('js/productdetailscarousel.js') }} ></script>
 </body>
 <footer>
     @include('partials.footer-info')


### PR DESCRIPTION

## Description

implement owl-carousel library that is a JavaScript library in product details page. use this library to make a more functional product image carousel. this carousel library allows to create a thumbnail images list below a main image container, so the user (buyer) can watch other images that exists in the list, while watching simultaneously a selected specific image



#### Before: 
![old-product-details-carousel](https://github.com/user-attachments/assets/ac7a4a52-3aab-4323-9419-9220eeb2c6f4)


#### After:

![new-product-details-carousel](https://github.com/user-attachments/assets/08868cf3-db16-40d2-b74e-c0db76eaface)


